### PR TITLE
Improvements to horizontal viewport check

### DIFF
--- a/lib/isInViewport.js
+++ b/lib/isInViewport.js
@@ -26,12 +26,17 @@
 
   //do is a reserved word and hence using it as a property throws on some browsers
   //it is now aliased as $.fn.run
-  $.fn['do'] = function(args) {
-    console.warn('isInViewport: .do causes issues in IE and some browsers since its a reserved. Use $.fn.run instead i.e., $(el).run(fn).');
-    return run(args);
-  };
-  $.fn.run = run;
-  
+  try {
+    $.fn.do = function(args) {
+      console.warn('isInViewport: .do causes issues in IE and some browsers since its a reserved. Use $.fn.run instead i.e., $(el).run(fn).');
+      return run(args);
+    };
+    $.fn.run = run;
+  }
+  catch (e) {
+    $.fn.run = run;
+  }
+
   //gets the width of the scrollbar
   function getScrollbarWidth(viewport) {
     var scrollBarWidth;
@@ -84,7 +89,7 @@
       top = top - $viewportOffset.top;
       bottom = bottom - $viewportOffset.top;
       left = left - $viewportOffset.left;
-      right = left + $viewportWidth;
+      right = right - $viewportOffset.left;
 
       //get the scrollbar width from cache or calculate it
       isInViewport.scrollBarWidth = isInViewport.scrollBarWidth || getScrollbarWidth($viewport);
@@ -104,10 +109,12 @@
     //the element is NOT in viewport iff it is completely out of
     //viewport laterally or if it is completely out of the tolerance
     //region. Therefore, if it is partially in view then it is considered
-    //to be in the viewport and hence true is returned
+    //to be in the viewport and hence true is returned. Because we have adjusted
+    //the left/right positions relative to the viewport, we should check the
+    //element's right against the viewport's 0 (left side), and the element's
+    //left against the viewport's width to see if it is outside of the viewport.
 
-    //if the element is laterally outside the viewport
-    if (Math.abs(left) >= $viewportWidth)
+    if (right <= 0 || left >= $viewportWidth)
       return isVisibleFlag;
 
     //if the element is bound to some tolerance


### PR DESCRIPTION
- Right was calculated incorrectly (but was never used), which has been fixed.
- The horizontal viewport check took the absolute value of the element's left,
  which didn't accurately check the viewport left/element right bound. This has
  been modified to check the element's left against the viewport's right
  (whether the element is within the right side of the viewport) and the
  element's right against the viewport's left (whether the element is within
  the left side of the viewport).
