### PR TITLE
using getBoundingClientRect() instead of $.offset() for viewport offset calculation

### DIFF
--- a/lib/isInViewport.js
+++ b/lib/isInViewport.js
@@ -78,12 +78,15 @@
     //bottom,left and right wrt the new viewport
     //the [object DOMWindow] check is for window object type in PhantomJS
     if (typeofViewport !== '[object Window]' && typeofViewport !== '[object DOMWindow]') {
-      var $viewportOffset = $viewport.offset();
+
+      // Use getBoundingClientRect() instead of $.Offset()
+      // since the original top/bottom positions are calculated relative to browser viewport and not document
+      var viewportRect = $viewport.get(0).getBoundingClientRect();
 
       //recalculate these relative to viewport
-      top = top - $viewportOffset.top;
-      bottom = bottom - $viewportOffset.top;
-      left = left - $viewportOffset.left;
+      top = top - viewportRect.top;
+      bottom = bottom - viewportRect.top;
+      left = left - viewportRect.left;
       right = left + $viewportWidth;
 
       //get the scrollbar width from cache or calculate it


### PR DESCRIPTION
when using $.offset(), the calculation becomes inaccurate as soon as the document is scrolled and viewport other than window is set. 