### PR TITLE
allow use as CommonJS

### DIFF
--- a/lib/isInViewport.js
+++ b/lib/isInViewport.js
@@ -145,4 +145,4 @@
         return isInViewport(currObj);
     }
   });
-})(window.jQuery, window);
+})(jQuery, window);


### PR DESCRIPTION
jQuery and window.jQuery are equal in context of simple page include.

Its impossible to use this plugin in context of CommonJS/WebPack because the shim requires to set jQuery dependancy outside the module and setting it global (window.jQuery) is just wrong, so usually you just set argument 'jQuery' in your shim to jquery like this

    require('imports?jQuery=jquery!is-in-viewport');

More on this http://webpack.github.io/docs/shimming-modules.html